### PR TITLE
proxy/models: return 1.0 from fit_score when no memory constraints configured - doesn't halt model load if no ram is configured

### DIFF
--- a/src/skvaider/proxy/models.py
+++ b/src/skvaider/proxy/models.py
@@ -89,6 +89,10 @@ class AIModel(BaseModel):
         the backend's free resources.
 
         """
+        # If no memory constraints are configured the model always fits.
+        # Returning 0 here would cause load_model to abort the load.
+        if not self.configured_memory:
+            return 1.0
         score = 0.0
         for resource, usage in self.configured_memory.items():
             if usage == 0:


### PR DESCRIPTION
Makes writing NixOS integration test for skvaider (fc-nixos PL-134151) easier. Test would use `memory = { ram = 1; }` to work around this.