### PR TITLE
inference: split embedding/numerical checks; warn when no reference data provided

### DIFF
--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -239,11 +239,16 @@ class Model(ABC):
         async with httpx.AsyncClient(
             timeout=self.health_check_timeout
         ) as client:
-            input_texts = ["health check"]
-            expected_embeddings: list[list[float]] | None = None
-            if self.verification_data:
-                input_texts = list(self.verification_data.keys())
-                expected_embeddings = list(self.verification_data.values())
+            input_texts = (
+                list(self.verification_data.keys())
+                if self.verification_data
+                else ["health check"]
+            )
+            expected_embeddings = (
+                list(self.verification_data.values())
+                if self.verification_data
+                else None
+            )
 
             resp = await client.post(
                 f"{self.endpoint}/v1/embeddings",
@@ -255,26 +260,29 @@ class Model(ABC):
 
             checks["embedding"] = ""
 
-            if expected_embeddings is not None:
-                data = resp.json()
-                for i, item in enumerate(data.get("data", [])):
-                    embedding = item.get("embedding", [])
-                    if not embedding:
-                        checks["numerical"] = "missing embedding"
-                        return checks
-                    expected = expected_embeddings[i]
-                    if len(embedding) != len(expected):
+            if expected_embeddings is None:
+                checks["numerical"] = "no reference data"
+                return checks
+
+            data = resp.json()
+            for i, item in enumerate(data.get("data", [])):
+                embedding = item.get("embedding", [])
+                if not embedding:
+                    checks["numerical"] = "missing embedding"
+                    return checks
+                expected = expected_embeddings[i]
+                if len(embedding) != len(expected):
+                    checks["numerical"] = (
+                        f"size mismatch: got {len(embedding)}, expected {len(expected)}"
+                    )
+                    return checks
+                for j, (a, b) in enumerate(zip(embedding, expected)):
+                    if abs(a - b) > 1e-2:
                         checks["numerical"] = (
-                            f"size mismatch: got {len(embedding)}, expected {len(expected)}"
+                            f"value mismatch at dim {j} for {input_texts[i]!r}: got {a:.6f}, expected {b:.6f}"
                         )
                         return checks
-                    for j, (a, b) in enumerate(zip(embedding, expected)):
-                        if abs(a - b) > 1e-2:
-                            checks["numerical"] = (
-                                f"value mismatch at dim {j} for {input_texts[i]!r}: got {a:.6f}, expected {b:.6f}"
-                            )
-                            return checks
-                checks["numerical"] = ""
+            checks["numerical"] = ""
         return checks
 
     async def _check_completion_health(self) -> dict[str, str]:

--- a/src/skvaider/inference/tests/test_health_monitoring.py
+++ b/src/skvaider/inference/tests/test_health_monitoring.py
@@ -85,8 +85,6 @@ async def test_health_check_embeddings(openai_server: OpenAIServerMock):
     model.endpoint = openai_server.endpoint
 
     expected_embedding = [0.1, 0.2, 0.3]
-    model.verification_data = {"test input": expected_embedding}
-
     openai_server.response = {
         "model": "test-embed",
         "object": "list",
@@ -95,10 +93,19 @@ async def test_health_check_embeddings(openai_server: OpenAIServerMock):
         ],
         "usage": {"prompt_tokens": 0, "total_tokens": 0},
     }
-    assert not any((await model._check_embedding_health()).values())
+
+    # 1. No verification data -> embedding ok, numerical warns
+    result = await model._check_embedding_health()
+    assert result["embedding"] == ""
+    assert result["numerical"] == "no reference data"
+
+    # 2. With verification data, correct embedding -> all ok
+    model.verification_data = {"test input": expected_embedding}
+    result = await model._check_embedding_health()
+    assert not any(result.values())
     assert openai_server.last_request_json["input"] == ["test input"]
 
-    # 2. Simulate wrong embedding -> unhealthy
+    # 3. Wrong embedding -> numerical fails
     openai_server.response["data"][0]["embedding"] = [0.9, 0.9, 0.9]
     assert any((await model._check_embedding_health()).values())
 


### PR DESCRIPTION
Splits the embedding health check into two named checks:

- `embedding`: HTTP reachability of the embeddings endpoint
- `numerical`: verification against reference data

Previously `numerical` was absent when no `verification_data` was configured, making it invisible in `/health`. Now it always emits `"no reference data"` as a warning when unconfigured, so operators can see that numerical verification is not set up.