### PR TITLE
inference: monitor memory for systemd-managed models

### DIFF
--- a/src/skvaider/conftest.py
+++ b/src/skvaider/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import prometheus_client
 import pytest
+import structlog
 import svcs
 from argon2 import PasswordHasher
 from fastapi import FastAPI, Request
@@ -28,11 +29,17 @@ from skvaider.config import (
     ServerConfig,
     parse_size,
 )
-from skvaider.proxy.backends import DummyBackend, SkvaiderBackend
+from skvaider.proxy.backends import (
+    BackendHealthRequest,
+    DummyBackend,
+    SkvaiderBackend,
+)
 from skvaider.proxy.models import AIModel
 from skvaider.proxy.pool import Pool
 from skvaider.routers.openai import OpenAIProxy
 from skvaider.utils import TaskManager
+
+log = structlog.stdlib.get_logger()
 
 hasher = PasswordHasher()
 
@@ -179,13 +186,34 @@ async def test_lifespan(
 
     await wait_for_healthy_backends()
 
-    @wait_for_condition()
+    @wait_for_condition(timeout=300)
     async def wait_for_models_active() -> bool:
         # Wait for at least one instance of each model to be active
-        return all(
-            pool.count_loaded_instances(model_id)
+        loaded = {
+            model_id: pool.count_loaded_instances(model_id)
             for model_id in pool.model_configs.keys()
-        )
+        }
+        if not all(loaded.values()):
+            # Dump backend health for debugging flaky CI
+            try:
+                health = await backend.backend_api(BackendHealthRequest())
+                log.warning(
+                    "waiting for models",
+                    loaded=loaded,
+                    backend_models=[
+                        {"id": m.id, "status": list(m.status)}
+                        for m in health.models
+                    ],
+                    backend_serial=str(health.current_serial),
+                )
+            except Exception as e:
+                log.warning(
+                    "waiting for models, health check failed",
+                    loaded=loaded,
+                    error=str(e),
+                )
+            return False
+        return True
 
     await wait_for_models_active()
 

--- a/src/skvaider/inference/__init__.py
+++ b/src/skvaider/inference/__init__.py
@@ -27,10 +27,11 @@ from skvaider.utils import TaskManager
 from .config import (
     LlamaServerModelConfig,
     ModelConfig,
+    SystemdDockerModelConfig,
     SystemdModelConfig,
     VllmModelConfig,
 )
-from .model import LlamaModel, SystemdModel, VllmModel
+from .model import LlamaModel, SystemdDockerModel, SystemdModel, VllmModel
 
 log = structlog.stdlib.get_logger()
 
@@ -95,6 +96,8 @@ async def lifespan(
             model = LlamaModel(model_config)
         elif isinstance(model_config, VllmModelConfig):
             model = VllmModel(model_config)
+        elif isinstance(model_config, SystemdDockerModelConfig):
+            model = SystemdDockerModel(model_config)
         elif isinstance(model_config, SystemdModelConfig):  # pyright: ignore[reportUnnecessaryIsInstance]
             model = SystemdModel(model_config)
         else:

--- a/src/skvaider/inference/config.py
+++ b/src/skvaider/inference/config.py
@@ -70,12 +70,17 @@ class SystemdModelConfig(ModelConfig):
     engine: Literal["systemd"] = "systemd"
     unit: str
     max_requests: int = 16
-    # If the systemd unit runs a Docker container, specify the container name here.
-    # When set, PIDs are resolved via `docker inspect` instead of MainPID.
-    docker_container: str | None = None
+
+
+class SystemdDockerModelConfig(SystemdModelConfig):
+    engine: Literal["systemd-docker"] = "systemd-docker"  # type: ignore[assignment]
+    docker_container: str
 
 
 AnyModelConfig = Annotated[
-    LlamaServerModelConfig | VllmModelConfig | SystemdModelConfig,
+    LlamaServerModelConfig
+    | VllmModelConfig
+    | SystemdModelConfig
+    | SystemdDockerModelConfig,
     Field(discriminator="engine"),
 ]

--- a/src/skvaider/inference/config.py
+++ b/src/skvaider/inference/config.py
@@ -66,14 +66,17 @@ class VllmModelConfig(ModelConfig):
     context_size: int
 
 
-class SystemdModelConfig(ModelConfig):
-    engine: Literal["systemd"] = "systemd"
+class SystemdModelConfigBase(ModelConfig):
     unit: str
     max_requests: int = 16
 
 
-class SystemdDockerModelConfig(SystemdModelConfig):
-    engine: Literal["systemd-docker"] = "systemd-docker"  # type: ignore[assignment]
+class SystemdModelConfig(SystemdModelConfigBase):
+    engine: Literal["systemd"] = "systemd"
+
+
+class SystemdDockerModelConfig(SystemdModelConfigBase):
+    engine: Literal["systemd-docker"] = "systemd-docker"
     docker_container: str
 
 

--- a/src/skvaider/inference/config.py
+++ b/src/skvaider/inference/config.py
@@ -70,6 +70,9 @@ class SystemdModelConfig(ModelConfig):
     engine: Literal["systemd"] = "systemd"
     unit: str
     max_requests: int = 16
+    # If the systemd unit runs a Docker container, specify the container name here.
+    # When set, PIDs are resolved via `docker inspect` instead of MainPID.
+    docker_container: str | None = None
 
 
 AnyModelConfig = Annotated[

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -32,6 +32,17 @@ from skvaider.utils import TaskManager, slugify
 
 log = structlog.get_logger()
 
+
+def walk_process_tree(root_pid: int) -> list[int]:
+    pids = [root_pid]
+    try:
+        parent = psutil.Process(root_pid)
+        pids += [c.pid for c in parent.children(recursive=True)]
+    except psutil.NoSuchProcess:
+        pass
+    return pids
+
+
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -128,13 +139,7 @@ class Model(ABC):
         """
         if not self.process:
             return []
-        pids = [self.process.pid]
-        try:
-            proc = psutil.Process(self.process.pid)
-            pids += [c.pid for c in proc.children(recursive=True)]
-        except psutil.NoSuchProcess:
-            pass
-        return pids
+        return walk_process_tree(self.process.pid)
 
     # Shared implementation:
 
@@ -658,21 +663,23 @@ class SystemdModel(Model):
     async def pids(self) -> list[int]:
         """Get PIDs belonging to this model.
 
-        Always resolves PIDs from the systemd unit's MainPID.
-        If docker_container is also configured, resolves and combines
+        Resolves PIDs from the systemd unit's MainPID.
+        If docker_container is configured, also resolves and combines
         container PIDs (deduplicated).
         """
-        pids = await self._pids_from_systemd_unit(self._config.unit)
+        pids: set[int] = set()
+        systemd_pid = await self.resolve_systemd_pid(self._config.unit)
+        if systemd_pid:
+            pids.update(walk_process_tree(systemd_pid))
         if self._config.docker_container:
-            docker_pids = await self._pids_from_docker(
+            docker_pid = await self.resolve_docker_pid(
                 self._config.docker_container
             )
-            seen = set(pids)
-            pids += [p for p in docker_pids if p not in seen]
-        return pids
+            if docker_pid:
+                pids.update(walk_process_tree(docker_pid))
+        return list(pids)
 
-    async def _pids_from_docker(self, container_name: str) -> list[int]:
-        """Resolve PIDs for a running docker container by name."""
+    async def resolve_docker_pid(self, container_name: str) -> int | None:
         proc = await asyncio.create_subprocess_exec(
             "docker",
             "inspect",
@@ -683,24 +690,14 @@ class SystemdModel(Model):
         )
         stdout, _ = await proc.communicate()
         if proc.returncode != 0:
-            return []
+            return None
         try:
-            container_pid = int(stdout.decode().strip())
+            pid = int(stdout.decode().strip())
         except ValueError:
-            return []
-        if container_pid == 0:
-            # Docker reports 0 when the container is not running
-            return []
-        pids = [container_pid]
-        try:
-            parent = psutil.Process(container_pid)
-            pids += [c.pid for c in parent.children(recursive=True)]
-        except psutil.NoSuchProcess:
-            pass
-        return pids
+            return None
+        return pid if pid != 0 else None
 
-    async def _pids_from_systemd_unit(self, unit: str) -> list[int]:
-        """Resolve PIDs from the systemd unit's MainPID."""
+    async def resolve_systemd_pid(self, unit: str) -> int | None:
         proc = await asyncio.create_subprocess_exec(
             "systemctl",
             "show",
@@ -711,26 +708,17 @@ class SystemdModel(Model):
         )
         stdout, _ = await proc.communicate()
         if proc.returncode != 0:
-            return []
-        # Output is "MainPID=1234\n"
+            return None
         value = stdout.decode().strip().removeprefix("MainPID=")
         try:
-            main_pid = int(value)
+            pid = int(value)
         except ValueError:
-            return []
-        if main_pid == 0:
-            # systemd reports 0 when the unit is not running
-            return []
-        pids = [main_pid]
-        try:
-            parent = psutil.Process(main_pid)
-            pids += [c.pid for c in parent.children(recursive=True)]
-        except psutil.NoSuchProcess:
-            pass
-        return pids
+            return None
+        return pid if pid != 0 else None
 
     @property
     def slug(self) -> str:
+        assert self.config.id is not None
         assert self.config.id is not None
         return slugify(self.config.id, 64)
 

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -18,6 +18,7 @@ from typing import (
 
 import anyio
 import httpx
+import psutil
 import structlog
 
 from skvaider.inference import metrics
@@ -119,6 +120,21 @@ class Model(ABC):
     async def download(self) -> None: ...
 
     async def start(self) -> None: ...
+
+    async def pids(self) -> list[int]:
+        """Return all PIDs belonging to this model's process tree.
+
+        Override in subclasses that don't own a subprocess directly (e.g. SystemdModel).
+        """
+        if not self.process:
+            return []
+        pids = [self.process.pid]
+        try:
+            proc = psutil.Process(self.process.pid)
+            pids += [c.pid for c in proc.children(recursive=True)]
+        except psutil.NoSuchProcess:
+            pass
+        return pids
 
     # Shared implementation:
 
@@ -637,6 +653,36 @@ class SystemdModel(Model):
     def __init__(self, config: SystemdModelConfig):
         super().__init__(config)
         self._config = config
+
+    async def pids(self) -> list[int]:
+        """Get PIDs from the systemd unit via systemctl show."""
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl",
+            "show",
+            "--property=MainPID",
+            self._config.unit,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return []
+        # Output is "MainPID=1234\n"
+        value = stdout.decode().strip().removeprefix("MainPID=")
+        try:
+            main_pid = int(value)
+        except ValueError:
+            return []
+        if main_pid == 0:
+            # systemd reports 0 when the unit is not running
+            return []
+        pids = [main_pid]
+        try:
+            parent = psutil.Process(main_pid)
+            pids += [c.pid for c in parent.children(recursive=True)]
+        except psutil.NoSuchProcess:
+            pass
+        return pids
 
     @property
     def slug(self) -> str:

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -26,7 +26,7 @@ from skvaider.inference.config import (
     LlamaServerModelConfig,
     ModelConfig,
     SystemdDockerModelConfig,
-    SystemdModelConfig,
+    SystemdModelConfigBase,
     VllmModelConfig,
 )
 from skvaider.utils import TaskManager, slugify
@@ -668,7 +668,7 @@ class SystemdModel(Model):
     # This one will probably move to be a integrated docker runner ?
     _engine = "systemd"
 
-    def __init__(self, config: SystemdModelConfig):
+    def __init__(self, config: SystemdModelConfigBase):
         super().__init__(config)
         self._config = config
 

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -648,6 +648,7 @@ class VllmModel(Model):
 
 
 class SystemdModel(Model):
+    # This one will probably move to be a integrated docker runner ?
     _engine = "systemd"
 
     def __init__(self, config: SystemdModelConfig):
@@ -655,12 +656,56 @@ class SystemdModel(Model):
         self._config = config
 
     async def pids(self) -> list[int]:
-        """Get PIDs from the systemd unit via systemctl show."""
+        """Get PIDs belonging to this model.
+
+        Always resolves PIDs from the systemd unit's MainPID.
+        If docker_container is also configured, resolves and combines
+        container PIDs (deduplicated).
+        """
+        pids = await self._pids_from_systemd_unit(self._config.unit)
+        if self._config.docker_container:
+            docker_pids = await self._pids_from_docker(
+                self._config.docker_container
+            )
+            seen = set(pids)
+            pids += [p for p in docker_pids if p not in seen]
+        return pids
+
+    async def _pids_from_docker(self, container_name: str) -> list[int]:
+        """Resolve PIDs for a running docker container by name."""
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "inspect",
+            "--format={{.State.Pid}}",
+            container_name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return []
+        try:
+            container_pid = int(stdout.decode().strip())
+        except ValueError:
+            return []
+        if container_pid == 0:
+            # Docker reports 0 when the container is not running
+            return []
+        pids = [container_pid]
+        try:
+            parent = psutil.Process(container_pid)
+            pids += [c.pid for c in parent.children(recursive=True)]
+        except psutil.NoSuchProcess:
+            pass
+        return pids
+
+    async def _pids_from_systemd_unit(self, unit: str) -> list[int]:
+        """Resolve PIDs from the systemd unit's MainPID."""
         proc = await asyncio.create_subprocess_exec(
             "systemctl",
             "show",
             "--property=MainPID",
-            self._config.unit,
+            unit,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -25,6 +25,7 @@ from skvaider.inference import metrics
 from skvaider.inference.config import (
     LlamaServerModelConfig,
     ModelConfig,
+    SystemdDockerModelConfig,
     SystemdModelConfig,
     VllmModelConfig,
 )
@@ -33,14 +34,25 @@ from skvaider.utils import TaskManager, slugify
 log = structlog.get_logger()
 
 
-def walk_process_tree(root_pid: int) -> list[int]:
-    pids = [root_pid]
+def walk_process_tree(root_pid: int) -> set[int]:
+    pids = {root_pid}
     try:
         parent = psutil.Process(root_pid)
-        pids += [c.pid for c in parent.children(recursive=True)]
+        pids.update(c.pid for c in parent.children(recursive=True))
     except psutil.NoSuchProcess:
         pass
     return pids
+
+
+async def run_command_stdout(*cmd: str) -> bytes | None:
+    """Run a command, return stdout bytes on success or None on failure."""
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    return stdout if proc.returncode == 0 else None
 
 
 P = ParamSpec("P")
@@ -132,13 +144,13 @@ class Model(ABC):
 
     async def start(self) -> None: ...
 
-    async def pids(self) -> list[int]:
+    async def pids(self) -> set[int]:
         """Return all PIDs belonging to this model's process tree.
 
         Override in subclasses that don't own a subprocess directly (e.g. SystemdModel).
         """
         if not self.process:
-            return []
+            return set()
         return walk_process_tree(self.process.pid)
 
     # Shared implementation:
@@ -660,54 +672,18 @@ class SystemdModel(Model):
         super().__init__(config)
         self._config = config
 
-    async def pids(self) -> list[int]:
-        """Get PIDs belonging to this model.
-
-        Resolves PIDs from the systemd unit's MainPID.
-        If docker_container is configured, also resolves and combines
-        container PIDs (deduplicated).
-        """
+    async def pids(self) -> set[int]:
         pids: set[int] = set()
         systemd_pid = await self.resolve_systemd_pid(self._config.unit)
         if systemd_pid:
             pids.update(walk_process_tree(systemd_pid))
-        if self._config.docker_container:
-            docker_pid = await self.resolve_docker_pid(
-                self._config.docker_container
-            )
-            if docker_pid:
-                pids.update(walk_process_tree(docker_pid))
-        return list(pids)
-
-    async def resolve_docker_pid(self, container_name: str) -> int | None:
-        proc = await asyncio.create_subprocess_exec(
-            "docker",
-            "inspect",
-            "--format={{.State.Pid}}",
-            container_name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await proc.communicate()
-        if proc.returncode != 0:
-            return None
-        try:
-            pid = int(stdout.decode().strip())
-        except ValueError:
-            return None
-        return pid if pid != 0 else None
+        return pids
 
     async def resolve_systemd_pid(self, unit: str) -> int | None:
-        proc = await asyncio.create_subprocess_exec(
-            "systemctl",
-            "show",
-            "--property=MainPID",
-            unit,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
+        stdout = await run_command_stdout(
+            "systemctl", "show", "--property=MainPID", unit
         )
-        stdout, _ = await proc.communicate()
-        if proc.returncode != 0:
+        if stdout is None:
             return None
         value = stdout.decode().strip().removeprefix("MainPID=")
         try:
@@ -718,7 +694,6 @@ class SystemdModel(Model):
 
     @property
     def slug(self) -> str:
-        assert self.config.id is not None
         assert self.config.id is not None
         return slugify(self.config.id, 64)
 
@@ -778,3 +753,35 @@ class SystemdModel(Model):
 
     async def download(self) -> None:
         pass
+
+
+class SystemdDockerModel(SystemdModel):
+    _engine = "systemd-docker"
+
+    def __init__(self, config: SystemdDockerModelConfig):
+        super().__init__(config)
+        self._config = config
+
+    async def pids(self) -> set[int]:
+        pids: set[int] = set()
+        systemd_pid = await self.resolve_systemd_pid(self._config.unit)
+        if systemd_pid:
+            pids.update(walk_process_tree(systemd_pid))
+        docker_pid = await self.resolve_docker_pid(
+            self._config.docker_container
+        )
+        if docker_pid:
+            pids.update(walk_process_tree(docker_pid))
+        return pids
+
+    async def resolve_docker_pid(self, container_name: str) -> int | None:
+        stdout = await run_command_stdout(
+            "docker", "inspect", "--format={{.State.Pid}}", container_name
+        )
+        if stdout is None:
+            return None
+        try:
+            pid = int(stdout.decode().strip())
+        except ValueError:
+            return None
+        return pid if pid != 0 else None

--- a/src/skvaider/inference/resources.py
+++ b/src/skvaider/inference/resources.py
@@ -96,20 +96,17 @@ class RAMMonitor(MemoryMonitor):
 
     async def update_model_usage(self) -> None:
         for model in self._manager.list_models():
-            if not model.process:
+            pids = await model.pids()
+            if not pids:
                 continue
-            try:
-                proc = psutil.Process(model.process.pid)
-                usage = proc.memory_info().rss
-                for child in proc.children(recursive=True):
-                    try:
-                        usage += child.memory_info().rss
-                    except psutil.NoSuchProcess:
-                        pass
-                current = self._model_usage.get(model.config.id, 0)
-                self._model_usage[model.config.id] = max(current, usage)
-            except psutil.NoSuchProcess:
-                pass
+            usage = 0
+            for pid in pids:
+                try:
+                    usage += psutil.Process(pid).memory_info().rss
+                except psutil.NoSuchProcess:
+                    pass
+            current = self._model_usage.get(model.config.id, 0)
+            self._model_usage[model.config.id] = max(current, usage)
 
             # Update Prometheus metrics
             metrics.inference_memory_bytes.labels(
@@ -183,15 +180,8 @@ class ROCmMemoryMonitor(MemoryMonitor):
         """Update VRAM usage for all models with a single rocm-smi call."""
         pid_to_model: dict[int, str] = {}
         for model in self._manager.list_models():
-            if not model.process:
-                continue
-            pid_to_model[model.process.pid] = model.config.id
-            try:
-                proc = psutil.Process(model.process.pid)
-                for child in proc.children(recursive=True):
-                    pid_to_model[child.pid] = model.config.id
-            except psutil.NoSuchProcess:
-                pass
+            for pid in await model.pids():
+                pid_to_model[pid] = model.config.id
 
         if not pid_to_model:
             return
@@ -314,15 +304,8 @@ class NvidiaMemoryMonitor(MemoryMonitor):
         """Update VRAM usage for all models with nvidia-smi."""
         pid_to_model: dict[int, str] = {}
         for model in self._manager.list_models():
-            if not model.process:
-                continue
-            pid_to_model[model.process.pid] = model.config.id
-            try:
-                proc = psutil.Process(model.process.pid)
-                for child in proc.children(recursive=True):
-                    pid_to_model[child.pid] = model.config.id
-            except psutil.NoSuchProcess:
-                pass
+            for pid in await model.pids():
+                pid_to_model[pid] = model.config.id
 
         if not pid_to_model:
             return

--- a/src/skvaider/inference/resources.py
+++ b/src/skvaider/inference/resources.py
@@ -97,8 +97,6 @@ class RAMMonitor(MemoryMonitor):
     async def update_model_usage(self) -> None:
         for model in self._manager.list_models():
             pids = await model.pids()
-            if not pids:
-                continue
             usage = 0
             for pid in pids:
                 try:


### PR DESCRIPTION
All three memory monitors (RAM, ROCm, Nvidia) previously skipped models without a `process` attribute, which excluded `SystemdModel` instances entirely.

Added `Model.pids() -> list[int]`:
- Default implementation walks the subprocess tree via `psutil` (covers llama-server and vllm)
- `SystemdModel` overrides it by querying `systemctl show --property=MainPID` and then walking that process tree

All three `update_model_usage` implementations now call `await model.pids()` instead of checking `model.process` directly.