### PR TITLE
debugger: reduce debugging DoS vectors

### DIFF
--- a/src/skvaider/config.py
+++ b/src/skvaider/config.py
@@ -64,7 +64,7 @@ class Config(BaseModel):
 class ServerConfig(BaseModel):
     host: str = "0.0.0.0"
     port: int = 8000
-    directory: Path = Path(".")
+    directory: Path
 
 
 class AuthConfig(BaseModel):

--- a/src/skvaider/conftest.py
+++ b/src/skvaider/conftest.py
@@ -4,6 +4,7 @@ import itertools
 import json
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -323,10 +324,10 @@ async def auth_header(
 
 
 @pytest.fixture
-def client() -> Generator[TestClient, None, None]:
+def client(tmp_path: Path) -> Generator[TestClient, None, None]:
     config = Config(
         auth=AuthConfig(admin_tokens=["asdf"]),
-        server=ServerConfig(),
+        server=ServerConfig(directory=tmp_path),
         backend=[],
         models=[],
         logging=LoggingConfig(),
@@ -340,6 +341,11 @@ def cleanup_prometheus_metrics():
     for m in metrics.__dict__.values():
         if isinstance(m, prometheus_client.metrics.MetricWrapperBase):
             m.clear()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_auth_cache():
+    skvaider.auth.cache.cache.clear()
 
 
 @pytest.fixture

--- a/src/skvaider/debug.py
+++ b/src/skvaider/debug.py
@@ -183,6 +183,14 @@ class DebugRecorder:
         path.write_text(_format_response(data))
 
     async def record(self) -> None:
+        if 400 <= self.status_code < 500:
+            # Never ever trigger debug recording for client-side issues
+            # except to avoid DoSing through unauthenticated requests or
+            # 404s or ...
+            self.enabled = False
+            self.triggers = []
+            return
+
         try:
             self.request_body_json = json.loads(
                 self.captured_request_body.decode("utf-8")
@@ -206,7 +214,7 @@ class DebugRecorder:
             time.time() - self.time_start > self.slow_threshold
         ):
             self.triggers.append("slow")
-        if self.status_code >= 400:
+        if self.status_code >= 500:
             self.triggers.append("error")
 
         if not self.triggers:

--- a/src/skvaider/logging.py
+++ b/src/skvaider/logging.py
@@ -6,6 +6,7 @@ from typing import Any
 import shortuuid
 import structlog
 from fastapi import Request
+from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from skvaider.config import LoggingConfig
@@ -36,6 +37,8 @@ class LoggingMiddleware:
     ):
         if message["type"] == "http.response.start":
             request.state.status_code = message["status"]
+            headers = MutableHeaders(scope=message)
+            headers["x-skvaider-request-id"] = request.state.request_id
         await send(message)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):

--- a/src/skvaider/routers/openai.py
+++ b/src/skvaider/routers/openai.py
@@ -313,22 +313,13 @@ class OpenAIProxy:
                     endpoint,
                     request_data,
                 )
-
-            request_id = request.state.request_id
-            if isinstance(result, StreamingResponse):
-                result.headers["X-Skvaider-Request-ID"] = request_id
-            else:
-                result = JSONResponse(
-                    content=result,
-                    headers={"X-Skvaider-Request-ID": request_id},
-                )
+            if not isinstance(result, StreamingResponse):
+                result = JSONResponse(content=result)
             return result
         except HTTPException as e:
             status = "error"
             raise HTTPException(
-                status_code=e.status_code,
-                detail=e.detail,
-                headers={"X-Skvaider-Request-ID": request.state.request_id},
+                status_code=e.status_code, detail=e.detail
             ) from e
         except Exception:
             status = "error"

--- a/src/skvaider/test_debug.py
+++ b/src/skvaider/test_debug.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_no_debug_by_default(
+    tmp_path: Path, client: TestClient, auth_header: None, llm_model_name: str
+):
+    response = client.post(
+        "/openai/v1/completions",
+        json={"model": "gemma"},
+    )
+    request_id = response.headers["x-skvaider-request-id"]
+    assert not (tmp_path / "debug" / f"{request_id}.request").exists()
+    assert not (tmp_path / "debug" / f"{request_id}.response").exists()
+
+
+def test_debug_via_header(
+    tmp_path: Path, client: TestClient, auth_header: None, llm_model_name: str
+):
+    response = client.post(
+        "/openai/v1/completions",
+        headers={"x-skvaider-debug": "yes"},
+        json={"model": "gemma"},
+    )
+    request_id = response.headers["x-skvaider-request-id"]
+    assert (tmp_path / "debug" / f"{request_id}.request").exists()
+    assert (tmp_path / "debug" / f"{request_id}.response").exists()
+
+
+def test_no_debug_if_unauthenticated(
+    tmp_path: Path, client: TestClient, llm_model_name: str
+):
+    response = client.post(
+        "/openai/v1/completions",
+        headers={"x-skvaider-debug": "yes"},
+        json={"model": "gemma"},
+    )
+    assert response.status_code == 403
+    request_id = response.headers["x-skvaider-request-id"]
+    assert not (tmp_path / "debug" / f"{request_id}.request").exists()
+    assert not (tmp_path / "debug" / f"{request_id}.response").exists()
+    assert not (tmp_path / "debug" / f"{request_id}.response").exists()


### PR DESCRIPTION
Unauthenticated users and obvious client-side issues (4xx) should not trigger the debugger.

Also some minor cleanups, including pushing the x-skvaider-request-id header injection properly into the logging middleware so all requests carry that header, not just the OpenAI proxy.

Re PL-135277