### PR TITLE
aramaki: fix two conditions for deadlocks

### DIFF
--- a/src/aramaki/collection.py
+++ b/src/aramaki/collection.py
@@ -147,6 +147,12 @@ class ReplicationManager:
 
     """
 
+    # TODO This could be improved using a more dynamic timeout that
+    # resets whenever we make progress to support longer catchups.
+    #
+    # seconds to wait for catchup steps before re-requesting
+    CATCHUP_TIMEOUT: float = 60
+
     catchup_running: bool = False
     tasks: set[asyncio.Task[Any]]
 
@@ -217,16 +223,19 @@ class ReplicationManager:
 
     async def process_update_message(self, msg: dict[str, Any]) -> None:
         log.debug("collection-process-update-message", id=msg.get("@id"))
-        await self.update_buffer.put(msg["version"], msg)
+        self.update_buffer.put(msg["version"], msg)
 
     async def process_update_buffer(self) -> None:
         while True:
             update_version, msg = await self.update_buffer.get()
-            assert msg["record_id"]  # defensive against peers breaking protocol
+            # XXX consider switching to pydantic models here
+            if not msg.get("record_id"):
+                # defensive against peers breaking protocol
+                continue
             log.debug(
                 "collection-process-update-message",
                 id=msg.get("@id"),
-                parition=msg["partition"],
+                partition=msg["partition"],
                 version=update_version,
             )
             async with (
@@ -261,7 +270,7 @@ class ReplicationManager:
 
                 if update_version > current_version + 1:
                     # This message is too new, keep it in the buffer and wait for another one
-                    await self.update_buffer.put_back(update_version, msg)
+                    self.update_buffer.put_back(update_version, msg)
                     continue
 
                 assert update_version == current_version + 1
@@ -403,7 +412,18 @@ class ReplicationManager:
                     )
 
             # Let the sync continue
-            await self.catchup_finished.wait()
+            try:
+                await asyncio.wait_for(
+                    self.catchup_finished.wait(), timeout=self.CATCHUP_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                log.error(
+                    "collection-catchup-timeout",
+                    partition=partition,
+                    start_version=start_version,
+                )
+                utils.create_task(self.request_catchup())
+                return
 
             if is_full_sync:
                 log.debug("collection-full-sync", status="finished")
@@ -416,7 +436,7 @@ class ReplicationManager:
                     )
 
     async def process_catchup_step_message(self, msg: dict[str, Any]) -> None:
-        await self.catchup_buffer.put(msg["from_version"], msg)
+        self.catchup_buffer.put(msg["from_version"], msg)
 
     async def process_catchup_step_buffer(self) -> None:
         while True:
@@ -441,7 +461,7 @@ class ReplicationManager:
                     continue
                 if msg["from_version"] > current_version:
                     # This message is too new, keep it in the buffer and wait for another one
-                    await self.catchup_buffer.put_back(from_version, msg)
+                    self.catchup_buffer.put_back(from_version, msg)
                     continue
 
                 record = await db_session.get(
@@ -486,35 +506,51 @@ class PriorityPushbackQueue:
     It also supports non-hashable objects.
 
     Putting an item back means we do not pass it out to waiters
-    until at least one another item has been put in.
+    until at least one another item with a lower priority
+    has been put in.
 
     """
 
     metric_put_back: int = 0
     items: dict[int, list[Any]]
     queue: asyncio.PriorityQueue[int]
+    last_put_back: int | None = None
 
     def __init__(self) -> None:
         self.items = {}
         self.queue = asyncio.PriorityQueue()
         self.new_item = asyncio.Event()
 
-    async def put(self, priority: int, item: Any) -> None:
+    def put(self, priority: int, item: Any) -> None:
         self.items.setdefault(priority, []).append(item)
-        await self.queue.put(priority)
+        self.queue.put_nowait(priority)
+        # Only signal new items if we haven't put anything back
+        # or got a higher priority since the last putback
+        if self.last_put_back and priority >= self.last_put_back:
+            return
+        self.last_put_back = None
         self.new_item.set()
 
-    async def put_back(self, priority: int, item: Any) -> None:
+    def put_back(self, priority: int, item: Any) -> None:
         self.metric_put_back += 1
         self.items.setdefault(priority, []).append(item)
-        self.new_item.clear()
-        await self.queue.put(priority)
+        if self.queue.empty() or self.queue._queue[0] >= priority:  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+            # If other items can in they must be of higher priority
+            # to allow immediately passing through without waiting
+            # for new items. There is a bit of further optimization
+            # possible if we'd keep track of the last priority that was
+            # put back and then not setting
+            self.new_item.clear()
+            self.last_put_back = priority
+        self.queue.put_nowait(priority)
         # The client should not mark this as "task done", we do that for it.
         self.queue.task_done()
 
     async def get(self) -> tuple[int, Any]:
         await self.new_item.wait()
-        priority = await self.queue.get()
+        priority = self.queue.get_nowait()
+        if self.queue.empty():
+            self.new_item.clear()
         return priority, self.items[priority].pop(0)
 
     async def join(self) -> None:

--- a/src/aramaki/tests/test_collection.py
+++ b/src/aramaki/tests/test_collection.py
@@ -111,26 +111,37 @@ async def test_null_record(tmp_path: Path):
 
 async def test_pushback_queue():
     queue = aramaki.collection.PriorityPushbackQueue()
-    await queue.put(3, "3")
-    await queue.put(1, "1")
-    await queue.put(2, "2")
+    queue.put(3, "3")
+    queue.put(1, "1")
+    queue.put(2, "2")
     assert await queue.get() == (1, "1")
     assert await queue.get() == (2, "2")
     assert await queue.get() == (3, "3")
 
-    await queue.put(3, "3")
-    await queue.put(2, "2")
+    queue.put(3, "3")
+    queue.put(2, "2")
     assert await queue.get() == (2, "2")
-    await queue.put_back(2, "2")
+    queue.put_back(2, "2")
 
     task = asyncio.create_task(queue.get())
     await asyncio.sleep(0.1)
     assert not task.done()
-    await queue.put(1, "1")
+    queue.put(1, "1")
     await task
     assert task.result() == (1, "1")
     assert await queue.get() == (2, "2")
     assert await queue.get() == (3, "3")
+
+
+async def test_pushback_queue_race_condition():
+    queue = aramaki.collection.PriorityPushbackQueue()
+    queue.put(2, "item 2")
+    p, _ = await queue.get()
+    assert p == 2
+    queue.put(1, "item 1")
+    queue.put_back(2, "item 2")
+    p, _ = await asyncio.wait_for(queue.get(), timeout=10.0)
+    assert p == 1
 
 
 class AramakiDummy:
@@ -432,6 +443,64 @@ async def test_replication_catchup_sync(tmp_path: Path):
 
         assert await collection.get("1") is None
         assert await collection.get("2") == {"key": "value-10"}
+
+
+async def test_catchup_timeout_releases_lock_and_rerequests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """If the server never sends is_final_record, the lock must not be held forever."""
+    db = aramaki.db.DBSessionManager(tmp_path)
+    db.upgrade()
+
+    aramaki_manager = AramakiDummy()
+    aramaki_manager.db = db
+
+    manager = aramaki.collection.ReplicationManager(
+        aramaki_manager,  # pyright: ignore[reportArgumentType]
+        DummyCollection,
+    )
+
+    manager.CATCHUP_TIMEOUT = 0.05
+
+    async with manager.get_collection_with_session():
+        await aramaki_manager.message_received.wait()
+        aramaki_manager.message_received.clear()
+        aramaki_manager.message = None
+
+        # Start catchup — server never sends is_final_record, catchup_finished never set
+        catchup_task = asyncio.create_task(
+            manager.process_start_catchup_message(
+                {"start_version": 6, "partition": "partition-1"}
+            )
+        )
+
+        # Timeout fires, re-requests catchup, releases update_lock
+        await asyncio.wait_for(
+            aramaki_manager.message_received.wait(), timeout=2
+        )
+
+        assert catchup_task.done()
+        assert aramaki_manager.message is not None
+        assert (
+            aramaki_manager.message[0][0]
+            == "directory.collection.catchup.request"
+        )
+
+        # update_lock must be released — update_buffer can drain without deadlocking
+        await manager.process_update_message(
+            {
+                "record_id": "1",
+                "partition": "partition-1",
+                "version": 1,
+                "change": "update",
+                "data": {"key": "value"},
+            }
+        )
+        # The update triggers another catchup (unknown partition), but the point
+        # is that update_buffer.join() completes — the lock is no longer held.
+        await asyncio.wait_for(manager.update_buffer.join(), timeout=1)
+
+    manager.stop()
 
 
 async def test_full_sync_deletes_superfluous_records_at_end(


### PR DESCRIPTION
a) a catchup that never finishes will block for ever - restart
   stuck catchups after 60 seconds

b) a race condition within the PushBackPriorityQueue may accidentally
   drop the signal for a new item if it intermingles incorrectly
   with another get and pushback action.

 Fixes PL-135329