### PR TITLE
debug: add 4-day TTL for automatic expiry of debug files

### DIFF
--- a/src/skvaider/__init__.py
+++ b/src/skvaider/__init__.py
@@ -162,6 +162,7 @@ def app_factory(
         DebuggingMiddleware,
         directory=config.server.directory / "debug",
         slow_threshold=config.debug.slow_threshold,
+        ttl_seconds=config.debug.ttl_days * 3600 * 24,
     )
     app.add_middleware(
         LoggingMiddleware,

--- a/src/skvaider/config.py
+++ b/src/skvaider/config.py
@@ -46,6 +46,7 @@ class ModelInstanceConfig(BaseModel):
 
 class DebugConfig(BaseModel):
     slow_threshold: float = 0
+    ttl_days: int = 4
 
 
 default_debug_config = DebugConfig()

--- a/src/skvaider/debug.py
+++ b/src/skvaider/debug.py
@@ -1,4 +1,6 @@
 import json
+import atexit
+import structlog.stdlib
 import re
 import time
 from datetime import datetime, timezone
@@ -7,6 +9,31 @@ from typing import Any
 
 from fastapi import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from skvaider.utils import TaskManager
+
+log = structlog.stdlib.get_logger()
+
+def cleanup_old_debug_files(directory: Path, ttl_seconds: float) -> int:
+    """Remove debug files older than ttl_seconds.
+
+    Returns the number of files removed.
+    """
+    if not directory.exists():
+        return 0
+    now = time.time()
+    removed = 0
+    for path in directory.iterdir():
+        if path.suffix not in (".request", ".response"):
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if now - mtime > ttl_seconds:
+            path.unlink()
+            removed += 1
+    return removed
 
 
 def sanitize_debug_id(value: str) -> str:
@@ -77,13 +104,43 @@ class DebuggingMiddleware:
 
     directory: Path
     slow_threshold: float
+    ttl_seconds: float
 
-    def __init__(self, app: ASGIApp, *, directory: Path, slow_threshold: float):
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        directory: Path,
+        slow_threshold: float,
+        ttl_seconds: float = 3600 * 24 * 4,
+    ):
         self.app = app
         self.directory = directory
         self.directory.mkdir(parents=True, exist_ok=True)
 
         self.slow_threshold = slow_threshold
+        self.ttl_seconds = ttl_seconds
+
+        removed = cleanup_old_debug_files(directory, ttl_seconds)
+        if removed:
+            log.info(
+                "removed expired debug files",
+                count=removed,
+                ttl_days=ttl_seconds / 3600 / 24,
+            )
+
+        tasks = TaskManager()
+        tasks.poll(self._cleanup, directory, ttl_seconds, interval=3600)
+        atexit.register(tasks.terminate)
+
+    async def _cleanup(self, directory: Path, ttl_seconds: float) -> None:
+        removed = cleanup_old_debug_files(directory, ttl_seconds)
+        if removed:
+            log.info(
+                "removed expired debug files",
+                count=removed,
+                ttl_days=ttl_seconds / 3600 / 24,
+            )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
         if scope["type"] != "http":

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -199,15 +199,7 @@ class Model(ABC):
                 new_checks = {"health": str(e) or type(e).__name__}
 
             self.health_checks = new_checks
-            new_status = (
-                "unhealthy"
-                if any(
-                    v
-                    for v in new_checks.values()
-                    if v and v != "no reference data"
-                )
-                else "healthy"
-            )
+            new_status = "unhealthy" if any(new_checks.values()) else "healthy"
             interval = self.health_check_interval
 
     async def _wait_for_startup(self) -> None:

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -199,7 +199,15 @@ class Model(ABC):
                 new_checks = {"health": str(e) or type(e).__name__}
 
             self.health_checks = new_checks
-            new_status = "unhealthy" if any(new_checks.values()) else "healthy"
+            new_status = (
+                "unhealthy"
+                if any(
+                    v
+                    for v in new_checks.values()
+                    if v and v != "no reference data"
+                )
+                else "healthy"
+            )
             interval = self.health_check_interval
 
     async def _wait_for_startup(self) -> None:

--- a/src/skvaider/tests/test_debug.py
+++ b/src/skvaider/tests/test_debug.py
@@ -1,0 +1,165 @@
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from skvaider.debug import cleanup_old_debug_files
+
+
+def test_cleanup_removes_old_request_files(tmp_path: Path):
+    """Files older than TTL are removed."""
+    old_file = tmp_path / "req-1.request"
+    old_file.write_text("old request data")
+    # Set mtime to 10 days ago
+    old_time = time.time() - 10 * 86400
+    os.utime(old_file, (old_time, old_time))
+
+    ttl_seconds = 4 * 86400  # 4 days
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 1
+    assert not old_file.exists()
+
+
+def test_cleanup_removes_old_response_files(tmp_path: Path):
+    """Old .response files are also removed."""
+    old_file = tmp_path / "req-1.response"
+    old_file.write_text("old response data")
+    old_time = time.time() - 5 * 86400
+    os.utime(old_file, (old_time, old_time))
+
+    ttl_seconds = 4 * 86400
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 1
+    assert not old_file.exists()
+
+
+def test_cleanup_keeps_recent_files(tmp_path: Path):
+    """Files within TTL are kept."""
+    recent = tmp_path / "req-2.request"
+    recent.write_text("recent data")
+    # mtime is now (default), so it's recent
+
+    ttl_seconds = 4 * 86400
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 0
+    assert recent.exists()
+
+
+def test_cleanup_ignores_non_debug_files(tmp_path: Path):
+    """Files without .request/.response suffix are ignored."""
+    other = tmp_path / "something.log"
+    other.write_text("not debug")
+    old_time = time.time() - 10 * 86400
+    os.utime(other, (old_time, old_time))
+
+    ttl_seconds = 4 * 86400
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 0
+    assert other.exists()
+
+
+def test_cleanup_handles_missing_directory():
+    """Returns 0 when directory doesn't exist, doesn't raise."""
+    removed = cleanup_old_debug_files(
+        Path("/nonexistent/path/that/does/not/exist"), 3600
+    )
+    assert removed == 0
+
+
+def test_cleanup_removes_both_pair(tmp_path: Path):
+    """When request is old, both .request and .response are removed."""
+    req = tmp_path / "req-1.request"
+    resp = tmp_path / "req-1.response"
+    req.write_text("req")
+    resp.write_text("resp")
+    old_time = time.time() - 5 * 86400
+    os.utime(req, (old_time, old_time))
+    os.utime(resp, (old_time, old_time))
+
+    ttl_seconds = 4 * 86400
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 2
+    assert not req.exists()
+    assert not resp.exists()
+
+
+def test_cleanup_mixed_ages(tmp_path: Path):
+    """Only old files are removed; recent files stay."""
+    old_req = tmp_path / "old.request"
+    old_req.write_text("old")
+    old_time = time.time() - 10 * 86400
+    os.utime(old_req, (old_time, old_time))
+
+    new_req = tmp_path / "new.request"
+    new_req.write_text("new")
+
+    ttl_seconds = 4 * 86400
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 1
+    assert not old_req.exists()
+    assert new_req.exists()
+
+
+def test_cleanup_handles_os_error_on_stat(tmp_path: Path):
+    """Files that can't be stat'd are skipped."""
+    import unittest.mock
+
+    file = tmp_path / "broken.request"
+    file.write_text("data")
+
+    original_stat = Path.stat
+
+    def selective_stat(self_self, *args, **kwargs):
+        if str(self_self) == str(file):
+            raise OSError("permission denied")
+        return original_stat(self_self, *args, **kwargs)
+
+    ttl_seconds = 4 * 86400
+    with unittest.mock.patch.object(Path, "stat", selective_stat):
+        removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 0
+    assert file.exists()
+
+
+def test_cleanup_empty_directory(tmp_path: Path):
+    """Empty directory returns 0 removed."""
+    removed = cleanup_old_debug_files(tmp_path, 3600)
+    assert removed == 0
+
+
+def test_cleanup_keeps_just_under_ttl(tmp_path: Path):
+    """File just under the TTL boundary is kept."""
+    ttl_seconds = 3600
+    req = tmp_path / "under.request"
+    req.write_text("data")
+    # Set mtime to TTL minus 1 second (under the threshold)
+    under_time = time.time() - (ttl_seconds - 1)
+    os.utime(req, (under_time, under_time))
+
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 0
+    assert req.exists()
+
+
+def test_cleanup_boundary_just_over_ttl(tmp_path: Path):
+    """File just over the TTL boundary IS removed."""
+    req = tmp_path / "over.request"
+    req.write_text("data")
+    ttl_seconds = 3600
+    # Set mtime to TTL + 1 second ago
+    over_time = time.time() - ttl_seconds - 1
+    os.utime(req, (over_time, over_time))
+
+    removed = cleanup_old_debug_files(tmp_path, ttl_seconds)
+
+    assert removed == 1
+    assert not req.exists()


### PR DESCRIPTION
Debug request data (.request/.response files) accumulates indefinitely. Add automatic cleanup.

## Changes

- **New `DebugConfig.ttl_days`** (int, default 4) — configurable in gateway TOML
- **`cleanup_old_debug_files(directory, ttl_seconds)`** — removes `.request`/`.response` files older than TTL based on file mtime
- **`DebuggingMiddleware`** runs cleanup once on init + periodically via `TaskManager.poll()` every hour
- `atexit.register(tasks.terminate)` for clean shutdown on process exit
- 11 tests covering TTL boundaries, mixed file ages, and edge cases

## Behavior

- Only `.request` and `.response` files are affected
- Uses file modification time (mtime) for age calculation
- Logs when files are removed: `removed expired debug files count=N ttl_days=4`
- If the debug directory doesn't exist yet, cleanup is a no-op