### PR TITLE
proxy: make save_state async with aiofiles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "rfc8785>=0.1.4",
     "structlog>=25.5.0",
     "aiosqlite>=0.21.0",
+    "aiofiles>=24.1.0",
     "alembic>=1.16.5",
     "argon2-cffi>=25.1.0",
     "uvicorn-worker>=0.3.0",

--- a/src/skvaider/proxy/backends.py
+++ b/src/skvaider/proxy/backends.py
@@ -322,7 +322,7 @@ class SkvaiderBackend(Backend):
                 )
                 self.map_up.mark("up")
                 self.map_in.mark("in")
-                self.pool.save_state()
+                await self.pool.save_state()
                 await self.pool.tasks.create(self.pool.rebalance)
             elif not self.healthy:
                 self.log.warning(
@@ -332,7 +332,7 @@ class SkvaiderBackend(Backend):
                 )
                 self.map_up.mark("down")
                 self.current_serial = Serial.floor()
-                self.pool.save_state()
+                await self.pool.save_state()
                 await self.pool.tasks.create(self.pool.rebalance)
 
             # Handle steady states
@@ -372,14 +372,14 @@ class SkvaiderBackend(Backend):
                 f"backend was DOWN for {self.DOWN_OUT_INTERVAL} - marking OUT"
             )
             self.map_in.mark("out")
-            self.pool.save_state()
+            await self.pool.save_state()
 
     async def _update_health(self) -> None:
         health = await self.backend_api(BackendHealthRequest())
 
         assert health.status == "ok"
         self.memory = health.usage
-        self.pool.save_state()
+        await self.pool.save_state()
         self.current_serial = health.current_serial
 
         from .models import AIModel

--- a/src/skvaider/proxy/pool.py
+++ b/src/skvaider/proxy/pool.py
@@ -1,10 +1,10 @@
 import asyncio
 import contextlib
 import datetime
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 
+import aiofiles
 import structlog
 from pydantic import BaseModel
 
@@ -201,9 +201,10 @@ class Pool:
                 model_obj = backend.models[model_id]
                 model_obj.memory_usage = model_record.memory_usage
 
-    def save_state(self) -> None:
+    async def save_state(self) -> None:
         if not self.state_file:
             return
+
         records = {
             backend.url: BackendStateRecord(
                 url=backend.url,
@@ -225,10 +226,11 @@ class Pool:
         }
         state = ClusterState(backends=records)
         data = state.model_dump_json(indent=2)
+
         tmp = self.state_file.with_suffix(".tmp")
-        tmp.write_text(data)
-        with tmp.open() as f:
-            os.fsync(f.fileno())
+        async with aiofiles.open(tmp, mode="w") as f:
+            await f.write(data)
+            await f.flush()
         tmp.rename(self.state_file)
 
     def placement_map(self) -> ModelMap:

--- a/src/skvaider/proxy/tests/test_pool.py
+++ b/src/skvaider/proxy/tests/test_pool.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+from pathlib import Path
 from typing import Callable
 from unittest.mock import patch
 
@@ -493,3 +494,29 @@ async def test_semaphore_use_yields_backend_and_releases(
     async with sem.use() as b:
         assert b is dummy_backend
     assert model.in_progress == 0
+
+
+async def test_save_state_writes_state_file(
+    dummy_backend: DummyBackend,
+    tmp_path: Path,
+):
+    """save_state() writes cluster state to disk asynchronously via aiofiles."""
+    dummy_backend.healthy = True
+    dummy_backend.memory = {"ram": {"free": 924, "total": 1024}}
+    registered_model_factory("m1", dummy_backend, ram=100)
+
+    pool = Pool(
+        [
+            ModelInstanceConfig(
+                id="m1", instances=1, memory={"ram": 100}, task="chat"
+            )
+        ],
+        [dummy_backend],
+        data_dir=tmp_path,
+    )
+
+    await pool.save_state()
+    assert pool.state_file is not None
+    assert pool.state_file.exists()
+    content = pool.state_file.read_text()
+    assert "m1" in content

--- a/uv.lock
+++ b/uv.lock
@@ -7,8 +7,17 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-28T13:00:10.445391Z"
+exclude-newer = "2026-05-11T09:30:56.232895Z"
 exclude-newer-span = "P7D"
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
 
 [[package]]
 name = "aiosqlite"
@@ -1029,6 +1038,7 @@ name = "skvaider"
 version = "0.1.0.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "anyio" },
@@ -1060,6 +1070,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "alembic", specifier = ">=1.16.5" },
     { name = "anyio", specifier = ">=4.0.0" },


### PR DESCRIPTION
save_state() did synchronous file I/O (write + fsync + rename) on the hot health-check path, blocking the event loop. Replace with aiofiles for non-blocking file write.

All four call sites in backends.py updated to await the async method.

Fixes PL-135349 - at least it should