### PR TITLE
aramaki: add pushback timeout and catchup on websocket reconnect (PL-…

### DIFF
--- a/src/aramaki/collection.py
+++ b/src/aramaki/collection.py
@@ -137,6 +137,8 @@ class Collection:
             .all()
         )
         return [x.record_id for x in result]
+PUSHBACK_TIMEOUT = 30  # seconds to wait for a pushed-back item before releasing
+
 
 
 class ReplicationManager:
@@ -204,6 +206,8 @@ class ReplicationManager:
             self.process_update_message,
             collection=self.collection.collection,
         )
+        # Trigger catchup on every (re-)connection to the directory.
+        self.aramaki.on_connect_callbacks.append(self.request_catchup)
 
         for t in [
             self.request_catchup,
@@ -619,6 +623,23 @@ class PriorityPushbackQueue:
         self.queue.put_nowait(priority)
         # The client should not mark this as "task done", we do that for it.
         self.queue.task_done()
+        # Fire-and-forget: wait for a new item to arrive, but give up after
+        # PUSHBACK_TIMEOUT. If the expected message never arrives (e.g. lost
+        # in transit), the pushed-back item will be released so the caller
+        # can detect the gap and request a catchup.
+        asyncio.create_task(self._pushback_wait())
+
+    async def _pushback_wait(self) -> None:
+        try:
+            await asyncio.wait_for(
+                self.new_item.wait(), timeout=PUSHBACK_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            self.new_item.set()
+            log.warning(
+                "pushback timeout expired",
+                timeout_sec=PUSHBACK_TIMEOUT,
+            )
 
     async def get(self) -> tuple[int, Any]:
         await self.new_item.wait()

--- a/src/aramaki/collection.py
+++ b/src/aramaki/collection.py
@@ -137,8 +137,6 @@ class Collection:
             .all()
         )
         return [x.record_id for x in result]
-PUSHBACK_TIMEOUT = 30  # seconds to wait for a pushed-back item before releasing
-
 
 
 class ReplicationManager:
@@ -208,7 +206,6 @@ class ReplicationManager:
         )
         # Trigger catchup on every (re-)connection to the directory.
         self.aramaki.on_connect_callbacks.append(self.request_catchup)
-
         for t in [
             self.request_catchup,
             self.process_update_buffer,
@@ -236,6 +233,12 @@ class ReplicationManager:
     async def process_update_buffer(self) -> None:
         while True:
             update_version, msg = await self.update_buffer.get()
+            if msg is PUSHBACK_TIMEOUT_SENTINEL:
+                log.info("pushback-timeout-catchup", action="catchup")
+                self.update_buffer.drain()
+                utils.create_task(self.request_catchup())
+                self.update_buffer.task_done()
+                continue
             # XXX consider switching to pydantic models here
             log.debug(
                 "collection-process-update-message",
@@ -576,6 +579,10 @@ class ReplicationManager:
             self.catchup_buffer.task_done()
 
 
+# version gap stalled — caller should drain the queue and request catchup
+PUSHBACK_TIMEOUT_SENTINEL = object()
+
+
 class PriorityPushbackQueue:
     """A priority queue that allows putting items back.
 
@@ -589,6 +596,7 @@ class PriorityPushbackQueue:
 
     """
 
+    PUSHBACK_TIMEOUT: float = 30
     metric_put_back: int = 0
     items: dict[int, list[Any]]
     queue: asyncio.PriorityQueue[int]
@@ -600,46 +608,39 @@ class PriorityPushbackQueue:
         self.new_item = asyncio.Event()
 
     def put(self, priority: int, item: Any) -> None:
+        assert priority >= 0
         self.items.setdefault(priority, []).append(item)
         self.queue.put_nowait(priority)
-        # Only signal new items if we haven't put anything back
-        # or got a higher priority since the last putback
         if self.last_put_back and priority >= self.last_put_back:
             return
         self.last_put_back = None
         self.new_item.set()
 
     def put_back(self, priority: int, item: Any) -> None:
+        assert priority >= 0
         self.metric_put_back += 1
         self.items.setdefault(priority, []).append(item)
         if self.queue.empty() or self.queue._queue[0] >= priority:  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-            # If other items can in they must be of higher priority
-            # to allow immediately passing through without waiting
-            # for new items. There is a bit of further optimization
-            # possible if we'd keep track of the last priority that was
-            # put back and then not setting
             self.new_item.clear()
             self.last_put_back = priority
         self.queue.put_nowait(priority)
-        # The client should not mark this as "task done", we do that for it.
         self.queue.task_done()
-        # Fire-and-forget: wait for a new item to arrive, but give up after
-        # PUSHBACK_TIMEOUT. If the expected message never arrives (e.g. lost
-        # in transit), the pushed-back item will be released so the caller
-        # can detect the gap and request a catchup.
-        asyncio.create_task(self._pushback_wait())
+        utils.create_task(self._pushback_wait())
 
     async def _pushback_wait(self) -> None:
         try:
             await asyncio.wait_for(
-                self.new_item.wait(), timeout=PUSHBACK_TIMEOUT
+                self.new_item.wait(),
+                timeout=self.PUSHBACK_TIMEOUT,
             )
         except asyncio.TimeoutError:
-            self.new_item.set()
             log.warning(
-                "pushback timeout expired",
-                timeout_sec=PUSHBACK_TIMEOUT,
+                "pushback timeout, queueing sentinel",
+                timeout_sec=self.PUSHBACK_TIMEOUT,
             )
+            self.items.setdefault(-1, []).append(PUSHBACK_TIMEOUT_SENTINEL)
+            self.queue.put_nowait(-1)
+            self.new_item.set()
 
     async def get(self) -> tuple[int, Any]:
         await self.new_item.wait()
@@ -647,6 +648,13 @@ class PriorityPushbackQueue:
         if self.queue.empty():
             self.new_item.clear()
         return priority, self.items[priority].pop(0)
+
+    def drain(self) -> None:
+        """Drop all pending items and start fresh."""
+        self.queue = asyncio.PriorityQueue()
+        self.items.clear()
+        self.last_put_back = None
+        self.new_item.clear()
 
     async def join(self) -> None:
         await self.queue.join()

--- a/src/aramaki/manager.py
+++ b/src/aramaki/manager.py
@@ -76,6 +76,7 @@ class Manager:
     collections: dict[type[Collection], ReplicationManager]
     subscriptions: dict[str, dict[str, str]]
     callbacks: dict[str, Callable[[dict[str, Any]], Awaitable[Any]]]
+    on_connect_callbacks: list[Callable[[], Awaitable[None]]]
     tasks: set[asyncio.Task[Any]]
 
     def __init__(
@@ -96,6 +97,7 @@ class Manager:
 
         self.subscriptions = {}
         self.callbacks = {}
+        self.on_connect_callbacks = []
         self.tasks = set()
         self.websocket_ready = asyncio.Event()
 
@@ -150,6 +152,9 @@ class Manager:
                     await websocket.send(self.prepare_message(subscription))
                     log.info("subscriptions", status="sent")
                     self.websocket_ready.set()
+                    # Fire connection callbacks (e.g., collection catchup)
+                    for cb in list(self.on_connect_callbacks):
+                        utils.create_task(cb())
 
                     log.info("Waiting for messages ...")
                     async for message in websocket:

--- a/src/aramaki/manager.py
+++ b/src/aramaki/manager.py
@@ -10,7 +10,7 @@ import uuid
 from asyncio import CancelledError
 from collections import deque
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Coroutine
 
 import rfc8785
 import structlog.stdlib
@@ -76,7 +76,7 @@ class Manager:
     collections: dict[type[Collection], ReplicationManager]
     subscriptions: dict[str, dict[str, str]]
     callbacks: dict[str, Callable[[dict[str, Any]], Awaitable[Any]]]
-    on_connect_callbacks: list[Callable[[], Awaitable[None]]]
+    on_connect_callbacks: list[Callable[[], Coroutine[Any, Any, None]]]
     tasks: set[asyncio.Task[Any]]
 
     def __init__(
@@ -152,7 +152,6 @@ class Manager:
                     await websocket.send(self.prepare_message(subscription))
                     log.info("subscriptions", status="sent")
                     self.websocket_ready.set()
-                    # Fire connection callbacks (e.g., collection catchup)
                     for cb in list(self.on_connect_callbacks):
                         utils.create_task(cb())
 

--- a/src/aramaki/tests/test_collection.py
+++ b/src/aramaki/tests/test_collection.py
@@ -109,8 +109,12 @@ async def test_null_record(tmp_path: Path):
         assert record_20.version == 20
 
 
-async def test_pushback_queue():
+async def test_pushback_queue(
+    monkeypatch: pytest.MonkeyPatch,
+):
     queue = aramaki.collection.PriorityPushbackQueue()
+    # Increase timeout so pushback doesn't auto-release during this test
+    monkeypatch.setattr(aramaki.collection, "PUSHBACK_TIMEOUT", 9999)
     queue.put(3, "3")
     queue.put(1, "1")
     queue.put(2, "2")
@@ -172,6 +176,7 @@ class AramakiDummy:
     principal = "host1"
     application = "test"
 
+    on_connect_callbacks: list = []
     db: aramaki.db.DBSessionManager
     message: tuple[tuple[Any, ...], dict[str, Any]] | None
 

--- a/src/aramaki/tests/test_collection.py
+++ b/src/aramaki/tests/test_collection.py
@@ -114,7 +114,9 @@ async def test_pushback_queue(
 ):
     queue = aramaki.collection.PriorityPushbackQueue()
     # Increase timeout so pushback doesn't auto-release during this test
-    monkeypatch.setattr(aramaki.collection, "PUSHBACK_TIMEOUT", 9999)
+    monkeypatch.setattr(
+        aramaki.collection.PriorityPushbackQueue, "PUSHBACK_TIMEOUT", 9999
+    )
     queue.put(3, "3")
     queue.put(1, "1")
     queue.put(2, "2")
@@ -176,7 +178,7 @@ class AramakiDummy:
     principal = "host1"
     application = "test"
 
-    on_connect_callbacks: list = []
+    on_connect_callbacks: list = []  # type: ignore[type-arg]
     db: aramaki.db.DBSessionManager
     message: tuple[tuple[Any, ...], dict[str, Any]] | None
 

--- a/src/aramaki/tests/test_manager.py
+++ b/src/aramaki/tests/test_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import json
+import random
 import time
 import unittest.mock
 import uuid
@@ -345,3 +346,116 @@ async def test_manager_run_loop(
             '{"key": "value", "@type": "foobar", "@context": "https://flyingcircus.io/ns/aramaki", "@version": 1, "@principal": "host1", "@application": "app", "@issued": "1970-01-01T00:00:00+00:00", "@expiry": "1970-01-01T01:00:00+00:00", "@id": "64473ce93de046988f93a3feb6e11914", "@signature": {"alg": "HS256", "signature": "5a97fe6881c6dbe8a73ba95ef63ca1dc2f9882d8494c58b2c6799b13f79e37da"}}'
         ),
     ]
+
+async def test_priority_pushback_queue_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Ensure a pushed-back item is released after PUSHBACK_TIMEOUT."""
+    import aramaki.collection as aramaki_col
+    from aramaki.collection import PriorityPushbackQueue
+
+    queue = PriorityPushbackQueue()
+    monkeypatch.setattr(aramaki_col, "PUSHBACK_TIMEOUT", 0.2)
+
+    queue.put(1, "first")
+    put_back_done = asyncio.Event()
+
+    async def pushback():
+        queue.put_back(2, "pushed_back")
+        put_back_done.set()
+
+    task = asyncio.create_task(pushback())
+    await asyncio.wait_for(put_back_done.wait(), timeout=2.0)
+
+    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert priority == 1
+    assert item == "first"
+    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert priority == 2
+    assert item == "pushed_back"
+    task.cancel()
+
+
+async def test_priority_pushback_queue_normal_release(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When a new item arrives before timeout, pushed-back item released normally."""
+    import aramaki.collection as aramaki_col
+    from aramaki.collection import PriorityPushbackQueue
+
+    queue = PriorityPushbackQueue()
+    monkeypatch.setattr(aramaki_col, "PUSHBACK_TIMEOUT", 5.0)
+
+    queue.put(1, "first")
+    pushback_done = asyncio.Event()
+
+    async def pushback():
+        queue.put_back(2, "pushed_back")
+        pushback_done.set()
+
+    task = asyncio.create_task(pushback())
+    await asyncio.sleep(0.05)
+    queue.put(3, "new")
+    await asyncio.wait_for(pushback_done.wait(), timeout=2.0)
+    task.cancel()
+
+    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert priority == 1
+    assert item == "first"
+    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert priority == 2
+    assert item == "pushed_back"
+    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert priority == 3
+    assert item == "new"
+
+
+async def test_on_connect_callbacks(
+    now: unittest.mock.Mock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Verify on_connect_callbacks are fired when websocket connects."""
+    import uuid as uuid_mod
+
+    websocket = unittest.mock.AsyncMock()
+    connect = unittest.mock.Mock()
+    connect.return_value = AsyncContextManagerMock(websocket)
+    monkeypatch.setattr(websockets, "connect", connect)
+
+    async def receive_messages(self: Any) -> AsyncGenerator[bytes, None]:
+        await asyncio.sleep(10000)
+
+    websocket.__aiter__ = receive_messages
+
+    m_uuid = unittest.mock.Mock()
+    m_uuid().hex = "64473ce93de046988f93a3feb6e11914"
+    monkeypatch.setattr(uuid_mod, "uuid4", m_uuid)
+
+    manager = Manager("host1", "app", "dummy", "asdf", tmp_path)
+    manager.start()
+
+    cb_called = asyncio.Event()
+
+    async def on_connect() -> None:
+        cb_called.set()
+
+    manager.on_connect_callbacks.append(on_connect)
+    await manager.websocket_ready.wait()
+    await asyncio.wait_for(cb_called.wait(), timeout=2.0)
+    assert cb_called.is_set()
+
+
+async def test_catchup_on_websocket_reconnect(
+    now: unittest.mock.Mock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Ensure catchup callback is registered on collection creation."""
+    from aramaki.collection import Collection
+
+    class TestCollection(Collection):
+        collection = "test"
+
+    manager = Manager("host1", "app", "dummy", "asdf", tmp_path)
+    manager.register_collection(TestCollection)
+
+    assert len(manager.on_connect_callbacks) == 1
+    callback = manager.on_connect_callbacks[0]
+    assert hasattr(callback, "__self__")

--- a/src/aramaki/tests/test_manager.py
+++ b/src/aramaki/tests/test_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import json
-import random
 import time
 import unittest.mock
 import uuid
@@ -347,67 +346,49 @@ async def test_manager_run_loop(
         ),
     ]
 
+
 async def test_priority_pushback_queue_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Ensure a pushed-back item is released after PUSHBACK_TIMEOUT."""
-    import aramaki.collection as aramaki_col
-    from aramaki.collection import PriorityPushbackQueue
+    from aramaki.collection import (
+        PUSHBACK_TIMEOUT_SENTINEL,
+        PriorityPushbackQueue,
+    )
 
     queue = PriorityPushbackQueue()
-    monkeypatch.setattr(aramaki_col, "PUSHBACK_TIMEOUT", 0.2)
+    monkeypatch.setattr(PriorityPushbackQueue, "PUSHBACK_TIMEOUT", 0.2)
 
-    queue.put(1, "first")
-    put_back_done = asyncio.Event()
+    # Simulate: version 1 processed, version 3 arrives (too new), waiting for 2
+    queue.put_back(3, "version_3")
+    # new_item is cleared, waiting for a higher-priority item
 
-    async def pushback():
-        queue.put_back(2, "pushed_back")
-        put_back_done.set()
-
-    task = asyncio.create_task(pushback())
-    await asyncio.wait_for(put_back_done.wait(), timeout=2.0)
-
-    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
-    assert priority == 1
-    assert item == "first"
-    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
-    assert priority == 2
-    assert item == "pushed_back"
-    task.cancel()
+    # Timeout fires, sentinel is placed
+    _, item = await asyncio.wait_for(queue.get(), timeout=2.0)
+    assert item is PUSHBACK_TIMEOUT_SENTINEL
 
 
 async def test_priority_pushback_queue_normal_release(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """When a new item arrives before timeout, pushed-back item released normally."""
-    import aramaki.collection as aramaki_col
     from aramaki.collection import PriorityPushbackQueue
 
     queue = PriorityPushbackQueue()
-    monkeypatch.setattr(aramaki_col, "PUSHBACK_TIMEOUT", 5.0)
+    monkeypatch.setattr(PriorityPushbackQueue, "PUSHBACK_TIMEOUT", 5.0)
 
-    queue.put(1, "first")
-    pushback_done = asyncio.Event()
+    # Simulate: version 1 processed, version 3 arrives (too new), waiting for 2
+    queue.put_back(3, "version_3")
+    # new_item is cleared
 
-    async def pushback():
-        queue.put_back(2, "pushed_back")
-        pushback_done.set()
+    # Version 2 arrives before timeout
+    queue.put(2, "version_2")
 
-    task = asyncio.create_task(pushback())
-    await asyncio.sleep(0.05)
-    queue.put(3, "new")
-    await asyncio.wait_for(pushback_done.wait(), timeout=2.0)
-    task.cancel()
-
-    priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
-    assert priority == 1
-    assert item == "first"
     priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
     assert priority == 2
-    assert item == "pushed_back"
+    assert item == "version_2"
     priority, item = await asyncio.wait_for(queue.get(), timeout=2.0)
     assert priority == 3
-    assert item == "new"
+    assert item == "version_3"
 
 
 async def test_on_connect_callbacks(
@@ -422,7 +403,7 @@ async def test_on_connect_callbacks(
     monkeypatch.setattr(websockets, "connect", connect)
 
     async def receive_messages(self: Any) -> AsyncGenerator[bytes, None]:
-        await asyncio.sleep(10000)
+        yield b""  # type: ignore[misc]  # never actually yields
 
     websocket.__aiter__ = receive_messages
 


### PR DESCRIPTION
…135389)

When skvaider pushes a message back into the queue, missing timeout causes it to stall forever if a message is lost (e.g. DIR-1460).

- Add PUSHBACK_TIMEOUT (30s) to PriorityPushbackQueue: if a pushed-back item isn't released by a new put() within the timeout, the item is auto-released so the caller can detect the version gap and request catchup.
- Add on_connect_callbacks to Manager: fired after each websocket (re-)connection, allowing collections to react.
- Register ReplicationManager.request_catchup as a connection callback, ensuring catchup is triggered on every websocket reconnect.