### PR TITLE
inference: log HTTPException errors at ERROR level before returning response

### DIFF
--- a/src/skvaider/inference/__init__.py
+++ b/src/skvaider/inference/__init__.py
@@ -12,7 +12,7 @@ import structlog.dev
 import structlog.stdlib
 import svcs
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 import skvaider.inference.routers.manager
@@ -165,6 +165,24 @@ def app_factory(config: Config, lifespan: Any = lifespan) -> FastAPI:
         return JSONResponse(
             status_code=500,
             content={"detail": "An internal server error occurred."},
+        )
+
+    @app.exception_handler(HTTPException)
+    async def _http_exception_handler(  # pyright: ignore[reportUnusedFunction]
+        request: Request, exc: HTTPException
+    ) -> JSONResponse:
+        """
+        Log HTTPException errors at ERROR level when status >= 500
+        before returning the default error response.
+        """
+        if exc.status_code >= 500:
+            log.error(
+                f"HTTP {exc.status_code} for request: {request.method} {request.url}",
+                detail=exc.detail,
+            )
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.detail},
         )
 
     return app

--- a/src/skvaider/inference/routers/manager.py
+++ b/src/skvaider/inference/routers/manager.py
@@ -67,6 +67,12 @@ async def update_manifest(
     models = {m.lower() for m in body.models}
     unknown = models - manager.models.keys()
     if unknown:
+        log.error(
+            "manifest rejected: unknown models",
+            unknown=sorted(unknown),
+            requested=sorted(models),
+            configured=sorted(manager.models.keys()),
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Unknown models: {sorted(unknown)}",


### PR DESCRIPTION
Removing a model from inference but not the gateway makes the system 500 forever.

The update_manifest handler raises HTTPException(500) when the gateway requests models the inference server doesn't know about. FastAPI's built-in handler catches this before the custom @app.exception_handler(Exception) gets it, so the error detail was silently swallowed -- only visible in the bare status code in access.log.

Fix:
- Add log.error() in manager.py before raising the HTTPException, including the unknown, requested, and configured model lists.
- Add @app.exception_handler(HTTPException) in the inference app that logs any HTTPException with status >= 500 at ERROR level with the full detail, then returns the standard error response.