### PR TITLE
PL-135522: log HTTPException errors at ERROR level before returning response

### DIFF
--- a/src/skvaider/inference/__init__.py
+++ b/src/skvaider/inference/__init__.py
@@ -12,8 +12,7 @@ import structlog.dev
 import structlog.stdlib
 import svcs
 import uvicorn
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI
 
 import skvaider.inference.routers.manager
 import skvaider.inference.routers.metrics
@@ -150,22 +149,24 @@ def app_factory(config: Config, lifespan: Any = lifespan) -> FastAPI:
         skip_paths=frozenset({"/metrics", "/manager/health"}),
     )
 
-    @app.exception_handler(Exception)
-    async def _exception_handler(  # pyright: ignore[reportUnusedFunction]
-        request: Request, exc: Exception
-    ) -> JSONResponse:
-        """
-        This catches all unhandled 500 errors anywhere in the app.
-        """
-        log.error(
-            f"Unhandled exception for request: {request.method} {request.url}",
-            exc_info=exc,
-        )
-
-        return JSONResponse(
-            status_code=500,
-            content={"detail": "An internal server error occurred."},
-        )
+    # We used to try to figure out which exception handlers to add for logging.
+    # However, we found out that we don't want specific error handlers here.
+    # The default works fine and behaves like this:
+    #
+    # 1. If the application explicitly raises an HTTPException, this is not logged
+    #    as that is the path for the application to communicate *known* error states.
+    #
+    #    This is also provided with JSON output and information for the client.
+    #
+    # 2. If the application raises other unexpected exceptions, this is logged with
+    #    a traceback because this is a technical malfunction.
+    #
+    #    This causes a generic server error without any detailsa s we might leak
+    #    sensitive information otherwise.
+    #
+    # Unfortunately we had to discover this by cross-testing the behaviour
+    # and cross-reading the starlette/fastapi docs as the intention isn't quite clear
+    # or obvious from any specific doc.
 
     return app
 

--- a/src/skvaider/inference/model.py
+++ b/src/skvaider/inference/model.py
@@ -404,7 +404,10 @@ class Model(ABC):
             )
         ]
         try:
-            client = openai.AsyncOpenAI(base_url=self.endpoint, api_key="")
+            assert self.endpoint
+            client = openai.AsyncOpenAI(
+                base_url=self.endpoint + "/v1", api_key=""
+            )
             s = client.chat.completions.stream(
                 model=self.config.id,
                 messages=messages,
@@ -465,7 +468,10 @@ class Model(ABC):
             )
         ]
         try:
-            client = openai.AsyncOpenAI(base_url=self.endpoint, api_key="")
+            assert self.endpoint
+            client = openai.AsyncOpenAI(
+                base_url=self.endpoint + "/v1", api_key=""
+            )
             resp = await client.chat.completions.create(
                 model=self.config.id,
                 messages=messages,
@@ -500,7 +506,10 @@ class Model(ABC):
             )
         ]
         try:
-            client = openai.AsyncOpenAI(base_url=self.endpoint, api_key="")
+            assert self.endpoint
+            client = openai.AsyncOpenAI(
+                base_url=self.endpoint + "/v1", api_key=""
+            )
             resp = await client.chat.completions.create(
                 model=self.config.id,
                 messages=messages,

--- a/src/skvaider/inference/routers/manager.py
+++ b/src/skvaider/inference/routers/manager.py
@@ -67,6 +67,12 @@ async def update_manifest(
     models = {m.lower() for m in body.models}
     unknown = models - manager.models.keys()
     if unknown:
+        log.error(
+            "manifest rejected: unknown models",
+            unknown=sorted(unknown),
+            requested=sorted(models),
+            configured=sorted(manager.models.keys()),
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Unknown models: {sorted(unknown)}",

--- a/src/skvaider/inference/routers/manager.py
+++ b/src/skvaider/inference/routers/manager.py
@@ -1,6 +1,6 @@
 import structlog
 import svcs
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from skvaider.inference.manager import Manager
@@ -64,18 +64,18 @@ async def update_manifest(
 ) -> JSONResponse:
     """Update the manifest of models to load; the manager converges asynchronously."""
     manager = services.get(Manager)
-    models = {m.lower() for m in body.models}
-    unknown = models - manager.models.keys()
-    if unknown:
-        log.error(
-            "manifest rejected: unknown models",
-            unknown=sorted(unknown),
-            requested=sorted(models),
-            configured=sorted(manager.models.keys()),
-        )
-        raise HTTPException(
-            status_code=500,
-            detail=f"Unknown models: {sorted(unknown)}",
-        )
+    unknown = body.models - manager.models.keys()
+    models = body.models - unknown
     manager.update_manifest(models, body.serial)
+    if unknown:
+        log.warning(
+            "manifest accepted with errors: unknown models",
+            unknown=sorted(unknown),
+            manifest=sorted(models),
+            known=sorted(manager.models.keys()),
+        )
+        return JSONResponse(
+            status_code=400,
+            content={"status": "unknown models", "unknown": sorted(unknown)},
+        )
     return JSONResponse(status_code=202, content={"status": "ok"})

--- a/src/skvaider/logging.py
+++ b/src/skvaider/logging.py
@@ -152,7 +152,7 @@ def logging_config(config: LoggingConfig) -> dict[str, Any]:
                 "propagate": False,
             },
         },
-        "root": {"handlers": ["console"]},
+        "root": {"handlers": ["console"], "level": "WARNING"},
     }
 
     common_config = {

--- a/src/skvaider/manifest.py
+++ b/src/skvaider/manifest.py
@@ -1,7 +1,7 @@
 import time
 from typing import Any, Literal
 
-from pydantic import GetCoreSchemaHandler
+from pydantic import GetCoreSchemaHandler, field_validator
 from pydantic_core import core_schema
 
 from skvaider.utils import RequestMethod, RequestModel, ResponseModel
@@ -121,3 +121,8 @@ class ManifestRequest(RequestModel[ManifestResponse]):
 
     models: set[str]
     serial: Serial
+
+    @field_validator("models", mode="after")
+    @classmethod
+    def normalize_models(cls, models: set[str]) -> set[str]:
+        return {m.lower() for m in models}

--- a/src/skvaider/proxy/backends.py
+++ b/src/skvaider/proxy/backends.py
@@ -289,66 +289,75 @@ class SkvaiderBackend(Backend):
     async def monitor_health_and_update_models(self) -> None:
         self.log.debug("starting monitor")
         while True:
-            was_healthy = self.healthy
-
-            in_progress = sum([x.in_progress for x in self.models.values()])
             try:
-                if in_progress:
-                    # XXX skip health check as we can't communicate out of band at the moment
-                    # otherwise we mark busy backends as dead too fast and cause superfluous
-                    # unloading of healthy models.
-                    pass
-                else:
-                    await self._update_health()
-                    self.healthy = True
-            except httpx.ConnectError as e:
-                self.healthy = False
-                self.unhealthy_reason = str(e)
-            except Exception as e:
-                self.healthy = False
-                self.unhealthy_reason = repr(e)
-            else:
-                self.unhealthy_reason = ""
-
-            # Handle state changes
-            if was_healthy == self.healthy:
-                # nothing happened
-                pass
-            elif self.healthy:
-                # we just became healthy
-                self.log.info(
-                    "backend became HEALTHY, marking UP and IN",
-                    backend=self.url,
+                await self._monitor_health_and_update_models()
+            except Exception:
+                self.log.exception(
+                    "An error occured monitoring health and updating models - restarting monitor"
                 )
-                self.map_up.mark("up")
-                self.map_in.mark("in")
-                await self.pool.save_state()
-                await self.pool.tasks.create(self.pool.rebalance)
-            elif not self.healthy:
-                self.log.warning(
-                    "backend became UNHEALTHY, marking DOWN",
-                    backend=self.url,
-                    reason=self.unhealthy_reason,
-                )
-                self.map_up.mark("down")
-                self.current_serial = Serial.floor()
-                await self.pool.save_state()
-                await self.pool.tasks.create(self.pool.rebalance)
-
-            # Handle steady states
-            if self.healthy:
-                await self.ensure_healthy()
             else:
-                await self.ensure_unhealthy()
-
-            self.request_health_update.clear()
+                self.request_health_update.clear()
             try:
+                # Will retry immediately if request_health_update did not clear.
                 await asyncio.wait_for(
                     self.request_health_update.wait(),
                     timeout=self.health_interval,
                 )
             except asyncio.TimeoutError:
                 pass
+
+    async def _monitor_health_and_update_models(self):
+        was_healthy = self.healthy
+
+        in_progress = sum([x.in_progress for x in self.models.values()])
+        try:
+            if in_progress:
+                # XXX skip health check as we can't communicate out of band at the moment
+                # otherwise we mark busy backends as dead too fast and cause superfluous
+                # unloading of healthy models.
+                pass
+            else:
+                await self._update_health()
+                self.healthy = True
+        except httpx.ConnectError as e:
+            self.healthy = False
+            self.unhealthy_reason = str(e)
+        except Exception as e:
+            self.healthy = False
+            self.unhealthy_reason = repr(e)
+        else:
+            self.unhealthy_reason = ""
+
+        # Handle state changes
+        if was_healthy == self.healthy:
+            # nothing happened
+            pass
+        elif self.healthy:
+            # we just became healthy
+            self.log.info(
+                "backend became HEALTHY, marking UP and IN",
+                backend=self.url,
+            )
+            self.map_up.mark("up")
+            self.map_in.mark("in")
+            await self.pool.save_state()
+            await self.pool.tasks.create(self.pool.rebalance)
+        elif not self.healthy:
+            self.log.warning(
+                "backend became UNHEALTHY, marking DOWN",
+                backend=self.url,
+                reason=self.unhealthy_reason,
+            )
+            self.map_up.mark("down")
+            self.current_serial = Serial.floor()
+            await self.pool.save_state()
+            await self.pool.tasks.create(self.pool.rebalance)
+
+        # Handle steady states
+        if self.healthy:
+            await self.ensure_healthy()
+        else:
+            await self.ensure_unhealthy()
 
     async def ensure_healthy(self):
         """Perform actions to keep a healthy backend updated and consistent.


### PR DESCRIPTION
PL-135522

Removing a model from inference but not the gateway makes the system 500 forever.

The update_manifest handler raises HTTPException(500) when the gateway requests models the inference server doesn't know about. FastAPI's built-in handler catches this before the custom @app.exception_handler(Exception) gets it, so the error detail was silently swallowed -- only visible in the bare status code in access.log.

Fix:
- Add log.error() in manager.py before raising the HTTPException, including the unknown, requested, and configured model lists.
- Add @app.exception_handler(HTTPException) in the inference app that logs any HTTPException with status >= 500 at ERROR level with the full detail, then returns the standard error response.